### PR TITLE
Fix trailing quote for ResoniteLibrayOutDir

### DIFF
--- a/Remora.Resonite.Sdk/Sdk/ProjectTypes/Shared.ModPlugin.targets
+++ b/Remora.Resonite.Sdk/Sdk/ProjectTypes/Shared.ModPlugin.targets
@@ -13,7 +13,7 @@
 
     <_LibraryOutputDirectory Condition="'$(_LibraryOutputDirectory)' == ''">$(_MainOutputDirectory)</_LibraryOutputDirectory>
     <LibraryOutDir>$(_RootOutDir)$(_LibraryOutputDirectory)</LibraryOutDir>
-    <ResoniteLibrayOutDir Condition="'$(_UseDefaultInstallProject)' == 'true'">$(ResoniteTargetPath)$(_LibraryOutputDirectory)"</ResoniteLibrayOutDir>
+    <ResoniteLibrayOutDir Condition="'$(_UseDefaultInstallProject)' == 'true'">$(ResoniteTargetPath)$(_LibraryOutputDirectory)</ResoniteLibrayOutDir>
 
     <PublishDir>$(_RootPublishDir)$(_MainOutputDirectory)</PublishDir>
     <LibraryPublishDir>$(_RootPublishDir)$(_LibraryOutputDirectory)</LibraryPublishDir>


### PR DESCRIPTION
This project is great! 

Noticed that it ends up copying mod dependencies with a quote when the rest of the attributes don't, pretty easy to spot in the log when building for BepisLoader:
```
Copying mod files to /home/user/.steam/steam/steamapps/common/Resonite/BepInEx/plugins/MyCoolPlugin/
Copying mod dependencies to /home/user/.steam/steam/steamapps/common/Resonite/BepInEx/plugins/MyCoolPlugin/"
```

This actually copies literally into a directory named `"` on Linux, which doesn't seem intentional? :P